### PR TITLE
Fix signed-magnitude conversions

### DIFF
--- a/dgldpc_shuffled_VNU/src/dgldpc_snuffled_VNU/compl2sm.sv
+++ b/dgldpc_shuffled_VNU/src/dgldpc_snuffled_VNU/compl2sm.sv
@@ -1,19 +1,19 @@
-module compl2sm                                                 // �?з Дополнительного кода в Прямой код
-    ( 
+module compl2sm                                                 // Из Дополнительного кода в Прямой код
+    (
         input  logic [8 : 0] i_data                        ,
-        output logic [8 : 0] o_data                                     
+        output logic [8 : 0] o_data
     )                                                       ;
-    
-    logic [7 : 0] sign_temp                                 ;
-    logic [7 : 0] data                                      ;
-    always_comb
-    begin
-        if (i_data[8] == 1) begin
-            sign_temp = '1                                  ;
-        end else           begin
-            sign_temp = '0                                  ;
+
+    logic [7 : 0] magnitude                                 ;
+
+    always_comb begin
+        if (i_data[8]) begin
+            magnitude = (~i_data[7 : 0]) + 1                ;
+        end else begin
+            magnitude = i_data[7 : 0]                       ;
         end
-        data = (i_data[7 : 0] ^ sign_temp)                  ;
-        o_data = {sign_temp, i_data[8] + data}              ;
+        o_data = {i_data[8], magnitude}                     ;
     end
+
 endmodule
+

--- a/dgldpc_shuffled_VNU/src/dgldpc_snuffled_VNU/sm2compl.sv
+++ b/dgldpc_shuffled_VNU/src/dgldpc_snuffled_VNU/sm2compl.sv
@@ -1,18 +1,17 @@
 module sm2compl                                                 // Из Прямого кода в Дополнительный код
-    ( 
+    (
         input  logic [5 : 0] i_data                         ,
         output logic [5 : 0] o_data                         ,
-        output logic         o_sign             
+        output logic         o_sign
     )                                                       ;
 
-    logic [4 : 0] compl_data                                ;
+    logic        compl_data                                 ;
 
-    always_comb             
-    begin               
+    always_comb begin
         compl_data = | i_data[4 : 0]                        ;
-        o_data     = {i_data[5], i_data[4 : 0] ^ {i_data[5], i_data[5], i_data[5], i_data[5], i_data[5]}} ;
-        o_sign     = compl_data & i_data[5]                 ;                         
+        o_data     = {i_data[5], i_data[4 : 0] ^ {5{i_data[5]}}};
+        o_sign     = compl_data & i_data[5]                 ;
     end
 
-
 endmodule
+


### PR DESCRIPTION
## Summary
- correct two's-complement to sign-magnitude conversion logic
- fix sign detection width and bit replication in sm2compl

## Testing
- `verilator --version` *(fails: command not found)*
- `iverilog -V` *(fails: command not found)*
- `apt-get install -y iverilog` *(fails: Unable to locate package iverilog)*

------
https://chatgpt.com/codex/tasks/task_e_68a1b2efd5c083289c7d2f8b91f6414b