### PR TITLE
Add SystemVerilog module for blinking three LEDs

### DIFF
--- a/led_blinker/README.md
+++ b/led_blinker/README.md
@@ -1,0 +1,15 @@
+# LED Blinker
+
+This module blinks three LEDs in sequence. The blink rate is determined by the
+`CLK_FREQ_HZ` and `BLINK_HZ` parameters. Each LED is lit one at a time, rotating
+through the three outputs.
+
+## Parameters
+- `CLK_FREQ_HZ`: clock frequency driving the design
+- `BLINK_HZ`: blink frequency for each LED
+
+## Ports
+- `clk`: input clock
+- `reset_n`: active-low synchronous reset
+- `led[2:0]`: LED outputs
+

--- a/led_blinker/src/led_blinker.sv
+++ b/led_blinker/src/led_blinker.sv
@@ -1,0 +1,26 @@
+module led_blinker #(
+    parameter int CLK_FREQ_HZ = 50_000_000,
+    parameter int BLINK_HZ    = 1
+) (
+    input  logic clk,
+    input  logic reset_n,
+    output logic [2:0] led
+);
+
+    localparam int DIV_COUNT = CLK_FREQ_HZ / (2 * BLINK_HZ);
+    localparam int CNT_WIDTH = $clog2(DIV_COUNT);
+
+    logic [CNT_WIDTH-1:0] counter;
+
+    always_ff @(posedge clk or negedge reset_n) begin
+        if (!reset_n) begin
+            counter <= '0;
+            led     <= 3'b001;
+        end else if (counter == DIV_COUNT - 1) begin
+            counter <= '0;
+            led     <= {led[1:0], led[2]};
+        end else begin
+            counter <= counter + 1'b1;
+        end
+    end
+endmodule


### PR DESCRIPTION
## Summary
- add parameterized led_blinker module
- document LED blinker usage and parameters

## Testing
- `iverilog -g2012 led_blinker/src/led_blinker.sv -o /tmp/led_blinker.out` (fails: command not found)
- `verilator --lint-only led_blinker/src/led_blinker.sv` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68bfe73db39083289c86f811e3a24e52